### PR TITLE
CAUS-8: adding balance assessment

### DIFF
--- a/causality/estimation/parametric.py
+++ b/causality/estimation/parametric.py
@@ -216,3 +216,11 @@ class PropensityScoreMatching(object):
         atc = self.estimate_ATC(X, assignment, outcome, confounder_types, n_neighbors=n_neighbors)
         p_assignment = len(X[X[assignment] == 1]) / float(len(X))
         return p_assignment*att + (1-p_assignment)*atc
+
+    def assess_balance(self, X, treated, control, assignment, confounders):
+        pass
+
+    def calculate_balance(self, X, x, d):
+        numerator = X[X[d] == 1].mean()[x] - X[X[d] == 0].mean()[x]
+        denominator = np.sqrt((X[X[d] == 1].var()[x] + X[X[d] == 0].var()[x])/2.)
+        return numerator / denominator

--- a/causality/estimation/parametric.py
+++ b/causality/estimation/parametric.py
@@ -3,6 +3,7 @@ from statsmodels.regression.linear_model import OLS
 from statsmodels.robust.robust_linear_model import RLM
 from statsmodels.discrete.discrete_model import Logit
 from sklearn.neighbors import NearestNeighbors
+import numpy as np
 
 
 class DifferenceInDifferences(object):
@@ -217,10 +218,27 @@ class PropensityScoreMatching(object):
         p_assignment = len(X[X[assignment] == 1]) / float(len(X))
         return p_assignment*att + (1-p_assignment)*atc
 
-    def assess_balance(self, X, treated, control, assignment, confounders):
-        pass
+    def assess_balance(self, X, treated, control, assignment, confounder_types):
+        initial_imbalances = {}
+        for confounder, confounder_type in confounder_types:
+            if confounder_type != 'c':
+                # find dummies and test each value
+                
+            else:
+                imbalance = self.calculate_imbalance(X, confounder, assignment)
+                initial_imbalances['confounder'] = imbalance
+        return initial_imbalances
 
     def calculate_balance(self, X, x, d):
+        """
+        Calculate the balance metric to assess how unbalanced x is across the two levels of (binary) treatment assignment,
+        d.
+
+        :param X: The data containing the test and control populations
+        :param x: The name of the confounding column.
+        :param d: The name of the treatment assignment variable.
+        :return:
+        """
         numerator = X[X[d] == 1].mean()[x] - X[X[d] == 0].mean()[x]
         denominator = np.sqrt((X[X[d] == 1].var()[x] + X[X[d] == 0].var()[x])/2.)
         return numerator / denominator


### PR DESCRIPTION
### Description

To make sure we're doing a good job w prop score matching, we want to assess the initial imbalance of the confounders across assignments, and then reassess after matching. We'll add an imbalance metric, and then add a method that calls it and does the matching so the analyst can experiment with difference settings.