### PR TITLE
 Improve Test Coverage For Independence Testing

### DIFF
--- a/causality/inference/independence_tests/__init__.py
+++ b/causality/inference/independence_tests/__init__.py
@@ -165,10 +165,12 @@ class MixedChiSquaredTest(object):
         @pymc.stochastic(name='joint_sample')
         def ci_joint(value=self.mcmc_initialization):
             def logp(value):
-                xi = [value[i] for i in range(len(x))]
-                yi = [value[i+len(x)] for i in range(len(y))]
-                zi = [value[i+len(x)+len(y)] for i in range(len(z))] 
-                if len(z) == 0:
+                x_length, y_length, z_length = len(self.x), len(self.y), len(self.z)
+                
+                xi = [value[i] for i in range(x_length)]
+                yi = [value[i + x_length] for i in range(y_length)]
+                zi = [value[i + x_length + y_length] for i in range(z_length)] 
+                if z_length == 0:
                     log_px_given_z = np.log(self.densities[0].pdf(data_predict=xi))
                     log_py_given_z = np.log(self.densities[1].pdf(data_predict=yi))
                     log_pz = 0.
@@ -184,7 +186,7 @@ class MixedChiSquaredTest(object):
         samples = self.N
         iterations = samples * thin + burn
         mcmc.sample(iter=iterations, burn=burn, thin=thin)
-        return pd.DataFrame(mcmc.trace('joint_sample')[:], columns=x+y+z)
+        return pd.DataFrame(mcmc.trace('joint_sample')[:], columns=self.x + self.y + self.z)
 
 
 class MutualInformationTest():

--- a/tests/unit/test_cit.py
+++ b/tests/unit/test_cit.py
@@ -5,7 +5,10 @@ import numpy.random
 import pandas as pd
 import networkx as nx
 
-from causality.inference.independence_tests import RobustRegressionTest, ChiSquaredTest, MutualInformationTest
+from causality.inference.independence_tests import (RobustRegressionTest,
+                                                    ChiSquaredTest,
+                                                    MutualInformationTest,
+                                                    MixedChiSquaredTest)
 
 TEST_SET_SIZE = 2000
 TRIALS = 2
@@ -42,7 +45,6 @@ class TestChi2(TestAPI):
         z = []
         test = ChiSquaredTest(y,x,z,self.X,self.alpha)
         assert(test.independent())
-
         
         x = ['a']
         y = ['c']
@@ -50,13 +52,11 @@ class TestChi2(TestAPI):
         test = ChiSquaredTest(y,x,z,self.X,self.alpha)
         assert(test.independent())
 
-
         x = ['a','b']
         y = ['c']
         z = ['d']
         test = ChiSquaredTest(y,x,z,self.X,self.alpha)
         assert(test.independent())
-
 
         x = ['a']
         y = ['b','c']
@@ -64,10 +64,43 @@ class TestChi2(TestAPI):
         test = ChiSquaredTest(y,x,z,self.X,self.alpha)
         assert(not test.independent())
 
+class TestMixedChi2(TestAPI):
+    def setUp(self):
+        TEST_SET_SIZE = 700
+        a = numpy.random.randn(TEST_SET_SIZE) * 3
+        b = numpy.random.randn(TEST_SET_SIZE) * 0.2 + a * 5        
+        c = numpy.random.randn(TEST_SET_SIZE) * 0.5 + a
+        d = numpy.random.randn(TEST_SET_SIZE)
+        self.X = pd.DataFrame({'a' : a,
+                               'b' : b,
+                               'c' : c, 
+                               'd' : d })        
+        self.variable_types = {'a': 'c',
+                               'b': 'c',
+                               'c': 'c',
+                               'd': 'c'}
+        self.alpha = 0.05
 
+    def test_mixed_chi2(self):        
+        x = ['b']
+        y = ['c']
+        z = ['a']
+        test = MixedChiSquaredTest(y, x, z,
+                                   self.X,
+                                   self.alpha,
+                                   self.variable_types)
+        assert(test.independent())
+
+        x = ['b']
+        y = ['c']
+        z = ['d']
+        test = MixedChiSquaredTest(y, x, z,
+                                   self.X,
+                                   self.alpha,
+                                   self.variable_types)
+        assert(not test.independent())
 
 class TestMutualInformation(TestAPI):
-
     def setUp(self):
         size = 1000
         x1 = numpy.random.choice(range(5), size=size)


### PR DESCRIPTION
Hi @akelleh, 

Wrote some tests to improve the coverage for the independence testing module, if the coverage is better I could assure that the behavior doesn't change when we transition from `pymc2` to `pymc3`. In the process of testing, I found a couple of bugs in the `MixedChiSquaredTest` function and added the fixes to this pull request. Do these look good? If not, what other tests should I write? 

Wanted to get your feedback before I write tests for the `MixedMutualInformationTest` function. 

Saul