### PR TITLE
Back door adjustments

### DIFF
--- a/causality/estimation/adjustments.py
+++ b/causality/estimation/adjustments.py
@@ -1,10 +1,13 @@
 from networkx.algorithms import is_directed_acyclic_graph
+import networkx as nx
+from pgmpy.models import BayesianModel
+from itertools import combinations
 
 class AdjustmentException(Exception):
     pass
 
 class AdjustForDirectCauses(object):
-    def __init__(self): 
+    def __init__(self):
         pass
 
     def find_predecessors(self, g, causes):
@@ -17,11 +20,91 @@ class AdjustForDirectCauses(object):
         if not is_directed_acyclic_graph(g):
             return False
         if not len(set(effects).intersection(set(causes).union(predecessors))) == 0:
-            return False 
-        return True 
+            return False
+        return True
 
     def admissable_set(self, g, causes, effects):
         predecessors = self.find_predecessors(g, causes)
         if not self.assumptions_satisfied(g, causes, effects, predecessors):
             raise AdjustmentException("Failed to satisfy adjustment assumptions")
         return predecessors
+
+class backDoorAdjustments(object):
+    def __init__(self,):
+        pass
+
+    def assumptions_satisfied(self, g, causes, effects):
+        if not is_directed_acyclic_graph(g):
+            raise AdjustmentException("Suplied Graph is not Directed and Acyclic")
+        if (len(causes)==0 or len(effects)==0):
+            raise AdjustmentException("Causes/Effects can not be empty")
+
+    def __areCausesDSeparatedFromEffects(self, g, s, causes, effects):
+        # Internal function to exit double loop
+        def isCauseDSeparatedFromEffects(g, s, cause, effects):
+            for effect in effects:
+                if g.is_active_trail(cause, effect, observed=s):
+                    return(False)
+            return(True)
+
+        causesDSeparatedFromEffectsInGraph = True
+        for cause in causes:
+            if not isCauseDSeparatedFromEffects(g,s,cause,effects):
+                causesDSeparatedFromEffectsInGraph = False
+                break
+        return(causesDSeparatedFromEffectsInGraph)
+
+
+    def minimalBackDoorAdmissableSets(self, g, causes, effects):
+
+        def isSupersetOfAny_setOfSets(s, setOfSets):
+            isSubset = False
+            for i in setOfSets:
+                if set(s).issuperset(i):
+                    isSubset = True
+                    break
+            return(isSubset)
+
+        # Check arguments
+        self.assumptions_satisfied(g, causes, effects)
+
+        # Bayesian Network is a DiGraph wrapper from pgmpy
+        # used because of its d-separation function (is_active_trail)
+        backDoorGraph = BayesianModel(nx.edges(g))
+        descendantsOfCauses = set()
+
+        # Create back door graph and collect descendants from causes
+        for cause in causes:
+            outEdgesOfCause = backDoorGraph.out_edges(cause)
+            descendantsOfCauses = descendantsOfCauses.union(nx.descendants(backDoorGraph,cause))
+            backDoorGraph.remove_edges_from(outEdgesOfCause)
+
+        # Possible adjustment nodes are those from the original graph that:
+        # i) Are not causes
+        # ii) Are not effects
+        # iii) Are not descendants of the causes
+        possibleAdjustmentNodes = set(backDoorGraph.nodes()).difference(set(causes),
+                                                                        set(effects),
+                                                                        set(descendantsOfCauses))
+        # Initialize outcome variable which will be a set of sets
+        minAdmissablesSets = set()
+
+        # If the empty set d-separates causes and effects in the back door graph
+        # then return the empty set
+        if self.__areCausesDSeparatedFromEffects(backDoorGraph, set(), causes, effects):
+            return(set())
+
+        # Check all set partitions of possibleAdjustmentNodes
+        for r in range(len(possibleAdjustmentNodes)):
+            for s in combinations(possibleAdjustmentNodes,r+1):
+                # Check s only if s is not a super set of any set already in minAdmissablesSets
+                if not isSupersetOfAny_setOfSets(s,minAdmissablesSets):
+                    # Only add set to minAdmissablesSets if all causes are d-Separated of causes
+                    if self.__areCausesDSeparatedFromEffects(backDoorGraph, s, causes, effects):
+                        minAdmissablesSets.add(frozenset(s))
+
+        # If after checking all combinations we don't find any admissable set then raise an Exception
+        if len(minAdmissablesSets)==0:
+            raise AdjustmentException("Failed to satisfy adjustment assumptions")
+
+        return(minAdmissablesSets)

--- a/tests/unit/adjustments.py
+++ b/tests/unit/adjustments.py
@@ -1,0 +1,37 @@
+import networkx as nx
+
+from causality.estimation.adjustments import backDoorAdjustments
+from tests.unit import TestAPI
+
+
+class TestBackDoorAdjustments(TestAPI):
+    def setUp(self):
+        # Graph from Causality (Judea Pearl) first edition pag.80
+        self.g = nx.DiGraph()
+        self.g.add_nodes_from(['x','y','x1','x2','x3','x4', 'x5','x6'])
+        self.g.add_edges_from([('x1','x3'),('x3','x'),('x1','x4'),('x2','x4'),
+                               ('x2','x5'),('x5','y'),('x4','x'),('x4','y'),
+                               ('x','x6'),('x6','y')])
+
+    def test_backdoor_adjustment_single_cause_single_effect(self):
+        causes = ['x']
+        effects = ['y']
+
+        adjustment = backDoorAdjustments()
+        minAdmissablesSets = adjustment.minimalBackDoorAdmissableSets(self.g,causes,effects)
+
+        realMinAdmissablesSets = {frozenset({'x2', 'x4'}),
+                                  frozenset({'x4', 'x5'}),
+                                  frozenset({'x3', 'x4'}),
+                                  frozenset({'x1', 'x4'})}
+        assert(realMinAdmissablesSets==minAdmissablesSets)
+
+    def test_backdoor_adjustment_multiple_causes_single_effect(self):
+        causes = ['x','x5']
+        effects = ['y']
+
+        adjustment = backDoorAdjustments()
+        minAdmissablesSets = adjustment.minimalBackDoorAdmissableSets(self.g,causes,effects)
+
+        realMinAdmissablesSets = {frozenset({'x4'})}
+        assert(realMinAdmissablesSets==minAdmissablesSets)


### PR DESCRIPTION
First version of exaustive search minimal admissable sets that satisfy the back door criterion.

It is based on a d-separation function from pgmpy package (https://github.com/pgmpy/pgmpy). It implements an algorithm found in "Probabilistic Graphical Models: Principles and Techniques" - Koller and Friedman. Is it possible to integrate that piece of code giving the proper credit to the coders? ( That packagee is under MIT License but I do not know much about licenses)

I have also found a polinomial time version of the minimal admissable sets algorithm described in https://arxiv.org/abs/1202.3764 by Johannes Textor and implementedin his cool project DAGitty (http://www.dagitty.net/dags.html) which is a javascript browser-based causal inference analyzer.

At the last minute I realized that you use different naming conventions for functions while I use camelCase  naming convention. I can change that later if the rest of the code is ok.