### PR TITLE
Fix 'Graph' object has no attribute 'node'

### DIFF
--- a/causality/inference/search/__init__.py
+++ b/causality/inference/search/__init__.py
@@ -44,9 +44,9 @@ class IC():
         self._g = nx.Graph()
         self._g.add_nodes_from(variable_types.keys())
         for var, var_type in variable_types.items():
-            self._g.node[var]['type'] = var_type
+            self._g.nodes[var]['type'] = var_type
         edges_to_add = []
-        for (node_a, node_b) in itertools.combinations(self._g.node.keys(), 2):
+        for (node_a, node_b) in itertools.combinations(self._g.nodes.keys(), 2):
             edges_to_add.append((node_a,node_b))
         self._g.add_edges_from(edges_to_add, marked=False)
 
@@ -121,7 +121,7 @@ class IC():
         """
         self.separating_sets = {}
         if not self.max_k:
-            self.max_k = len(self._g.node)+1
+            self.max_k = len(self._g.nodes)+1
         for N in range(self.max_k + 1):
             for (x, y) in list(self._g.edges()):
                 x_neighbors = list(self._g.neighbors(x))

--- a/tests/unit/test_IC.py
+++ b/tests/unit/test_IC.py
@@ -36,7 +36,7 @@ class Test_IC(TestAPI):
         assert(len(self.ic._g.edges()) == (V-1)*V / 2) 
         assert(set(self.ic._g.nodes()) == set(self.variable_types.keys()))
         for node, variable_type in self.variable_types.items():
-            assert(self.ic._g.node[node]['type'] == variable_type)
+            assert(self.ic._g.nodes[node]['type'] == variable_type)
         for i, j in self.ic._g.edges():
             assert(self.ic._g.get_edge_data(i, j)['marked'] == False)
 


### PR DESCRIPTION
Fix for #82, making the module compatible with NetworkX 2.4, see [here](https://stackoverflow.com/questions/58518554/attributeerror-graph-object-has-no-attribute-node)  